### PR TITLE
Issue #21 : Add function `add` with parameters and return type

### DIFF
--- a/demo/main.ast
+++ b/demo/main.ast
@@ -20,3 +20,8 @@ function main()
     Return Statement:
         Value: c 
 }
+function add(a: int, b: int, c: bool) -> int 
+{
+    Return Statement:
+        Value: (a + b) 
+}

--- a/demo/main.su
+++ b/demo/main.su
@@ -12,3 +12,7 @@ func main() {
     }
     return c;
 }
+
+func add(a: int, b: int, c : bool) -> int {
+    return a + b;
+}

--- a/src/ast/item/function/fn_params.rs
+++ b/src/ast/item/function/fn_params.rs
@@ -1,0 +1,53 @@
+use crate::{
+    ast::types::TypeRef,
+    errors::ParserError,
+    lexer::token::{PuncuationKind, TokenKind},
+    parser::Parser,
+};
+use anyhow::Result;
+use core::fmt;
+
+pub struct Param {
+    pub name: String,
+    pub type_ref: TypeRef,
+}
+
+impl fmt::Display for Param {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.name, self.type_ref)
+    }
+}
+impl Param {
+    pub fn parse_params(parser: &mut Parser) -> Result<Vec<Param>> {
+        let mut params: Vec<Param> = Vec::new();
+        parser.expect(TokenKind::Punctuation(PuncuationKind::LeftParen))?;
+        while TokenKind::Punctuation(PuncuationKind::RightParen) != parser.peek()?.kind {
+            let name: String;
+            let tok = parser.peek()?;
+            match &tok.kind {
+                TokenKind::Ident(id) => {
+                    name = id.clone();
+                    parser.consume()?;
+                }
+                _ => {
+                    return Err(ParserError::ExpectedTokenGotUnexpected {
+                        kind: TokenKind::Ident("Ident".to_string()),
+                        got: tok.clone(),
+                    }
+                    .into());
+                }
+            }
+
+            parser.expect(TokenKind::Punctuation(PuncuationKind::Colon))?;
+
+            let type_ref = TypeRef::parse_type_ref(parser)?;
+
+            if parser.peek()?.kind != TokenKind::Punctuation(PuncuationKind::RightParen) {
+                parser.expect(TokenKind::Punctuation(PuncuationKind::Comma))?;
+            }
+            params.push(Param { name, type_ref });
+        }
+        parser.expect(TokenKind::Punctuation(PuncuationKind::RightParen))?;
+        Ok(params)
+    }
+}

--- a/src/ast/item/function/fn_return.rs
+++ b/src/ast/item/function/fn_return.rs
@@ -1,0 +1,26 @@
+use crate::{ast::types::TypeRef, lexer::token::OperatorKind, parser::Parser};
+use anyhow::Result;
+
+pub struct FnReturn {
+    pub type_ref: TypeRef,
+}
+
+impl std::fmt::Display for FnReturn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.type_ref)
+    }
+}
+
+impl FnReturn {
+    pub fn parse_fn_return(parser: &mut Parser) -> Result<FnReturn> {
+        parser.expect(crate::lexer::token::TokenKind::Operator(
+            OperatorKind::Minus,
+        ))?;
+        parser.expect(crate::lexer::token::TokenKind::Operator(
+            OperatorKind::Greater,
+        ))?;
+        let type_ref = TypeRef::parse_type_ref(parser)?;
+
+        Ok(FnReturn { type_ref })
+    }
+}

--- a/src/ast/item/function/mod.rs
+++ b/src/ast/item/function/mod.rs
@@ -1,32 +1,46 @@
+use anyhow::{Context, Result};
 use core::fmt;
 
-use anyhow::{Context, Result};
-
 use crate::{
-    ast::block::Block,
+    ast::{
+        block::Block,
+        item::function::{fn_params::Param, fn_return::FnReturn},
+    },
     errors::ParserError,
-    lexer::token::{KeywordKind, PuncuationKind, Token, TokenKind},
+    lexer::token::{KeywordKind, OperatorKind, PuncuationKind, TokenKind},
     parser::Parser,
 };
 
+pub mod fn_params;
+pub mod fn_return;
+
 pub struct FuncItem {
     pub name: String,
-    pub params: Option<Vec<Token>>,
+    pub params: Option<Vec<Param>>,
+    pub return_type: Option<FnReturn>,
     pub body: Block,
 }
 
 impl FuncItem {
-    pub fn new(name: String, params: Option<Vec<Token>>, body: Block) -> Self {
-        FuncItem { name, params, body }
+    pub fn new(
+        name: String,
+        params: Option<Vec<Param>>,
+        return_type: Option<FnReturn>,
+        body: Block,
+    ) -> Self {
+        FuncItem {
+            name,
+            params,
+            return_type,
+            body,
+        }
     }
 
     pub fn parse(parser: &mut Parser) -> Result<FuncItem> {
         let name: String;
-        let next = parser.peek()?;
-        match next.kind {
-            TokenKind::Keyword(KeywordKind::Func) => parser.consume()?,
-            _ => return Err(ParserError::UnexpectedEndOfInput.into()),
-        };
+
+        parser.expect(TokenKind::Keyword(KeywordKind::Func))?;
+
         let next = parser.peek()?;
         match &next.kind {
             TokenKind::Ident(id) => {
@@ -40,9 +54,16 @@ impl FuncItem {
                 .into());
             }
         }
+        let params = Param::parse_params(parser)?;
+
+        let mut return_type: Option<FnReturn> = None;
+
         let next = parser.peek()?;
         match next.kind {
-            TokenKind::Punctuation(PuncuationKind::LeftParen) => parser.consume()?,
+            TokenKind::Operator(OperatorKind::Minus) => {
+                return_type = Some(FnReturn::parse_fn_return(parser)?);
+            }
+            TokenKind::Punctuation(PuncuationKind::LeftCurlyParen) => {}
             _ => {
                 return Err(ParserError::UnexpectedToken {
                     token: next.clone(),
@@ -50,16 +71,7 @@ impl FuncItem {
                 .into());
             }
         };
-        let next = parser.peek()?;
-        match next.kind {
-            TokenKind::Punctuation(PuncuationKind::RightParen) => parser.consume()?,
-            _ => {
-                return Err(ParserError::UnexpectedToken {
-                    token: next.clone(),
-                }
-                .into());
-            }
-        };
+
         let next = parser.peek()?;
         match next.kind {
             TokenKind::Punctuation(PuncuationKind::LeftCurlyParen) => {}
@@ -71,11 +83,23 @@ impl FuncItem {
             }
         };
 
-        let params: Option<Vec<Token>> = None;
-
         let body = Block::parse(parser).context("Error while parsing function body")?;
 
-        Ok(FuncItem { name, params, body })
+        if params.len() == 0 {
+            return Ok(FuncItem {
+                name,
+                body,
+                params: None,
+                return_type,
+            });
+        }
+
+        Ok(FuncItem {
+            name,
+            params: Some(params),
+            body,
+            return_type,
+        })
     }
 }
 
@@ -83,11 +107,18 @@ impl fmt::Display for FuncItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "function {}(", self.name)?;
         if let Some(params) = &self.params {
-            for param in params {
+            for (i, param) in params.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
                 write!(f, "{}", param)?;
             }
         }
-        write!(f, ") \n{}\n", self.body)?;
+        if let Some(return_type) = &self.return_type {
+            write!(f, ") -> {} \n{}\n", return_type, self.body)?;
+        } else {
+            write!(f, ") \n{}\n", self.body)?;
+        }
         Ok(())
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5,6 +5,7 @@ pub mod item;
 pub mod let_statement;
 pub mod return_statement;
 pub mod statement;
+pub mod types;
 
 pub struct Ast {
     pub items: Vec<Item>,

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,0 +1,51 @@
+use crate::{
+    errors::{ParserError, span::Span},
+    lexer::token::{KeywordKind, TokenKind},
+    parser::Parser,
+};
+use anyhow::Result;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+pub enum TypeRef {
+    Name { name: String, span: Span },
+}
+
+impl Display for TypeRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            TypeRef::Name { name, .. } => write!(f, "{}", name),
+        }
+    }
+}
+
+impl TypeRef {
+    pub fn parse_type_ref(parser: &mut Parser) -> Result<TypeRef> {
+        let tok = parser.peek()?;
+        let type_ref = match tok.kind {
+            TokenKind::Keyword(KeywordKind::Int) => {
+                let tok = tok.clone();
+                parser.consume()?;
+                TypeRef::Name {
+                    name: "int".to_string(),
+                    span: tok.span,
+                }
+            }
+            TokenKind::Keyword(KeywordKind::Bool) => {
+                let tok = tok.clone();
+                parser.consume()?;
+                TypeRef::Name {
+                    name: "bool".to_string(),
+                    span: tok.span,
+                }
+            }
+            _ => {
+                return Err(ParserError::ExpectedTokenGotUnexpected {
+                    kind: TokenKind::Ident("Ident".to_string()),
+                    got: tok.clone(),
+                }
+                .into());
+            }
+        };
+        Ok(type_ref)
+    }
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -67,6 +67,8 @@ impl<'a> Lexer<'a> {
             "func" => TokenKind::Keyword(KeywordKind::Func),
             "struct" => TokenKind::Keyword(KeywordKind::Struct),
             "let" => TokenKind::Keyword(KeywordKind::Let),
+            "int" => TokenKind::Keyword(KeywordKind::Int),
+            "bool" => TokenKind::Keyword(KeywordKind::Bool),
             _ => TokenKind::Ident(ident.to_string()),
         }
     }

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -55,6 +55,8 @@ pub enum KeywordKind {
     Return,
     Func,
     Struct,
+    Int,
+    Bool,
 }
 
 impl fmt::Display for Token {
@@ -104,6 +106,8 @@ impl fmt::Display for KeywordKind {
             KeywordKind::Return => write!(f, "Return"),
             KeywordKind::Func => write!(f, "Function"),
             KeywordKind::Struct => write!(f, "Struct"),
+            KeywordKind::Int => write!(f, "Int"),
+            KeywordKind::Bool => write!(f, "Bool"),
         }
     }
 }

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -5,7 +5,6 @@ pub struct TypeId(pub usize);
 pub enum TypeKind {
     Int,
     Bool,
-    Float,
     Pointer(TypeId),
     Function {
         params: Vec<TypeId>,


### PR DESCRIPTION
- Added a new function `add` that takes two integers and a boolean as parameters, returning an integer.
- Updated the AST parsing to support function parameter and return type declarations.