### PR TITLE
Issue #16, #21 : Refactor function parameter and return types to include

### DIFF
--- a/src/ast/item/function/fn_return.rs
+++ b/src/ast/item/function/fn_return.rs
@@ -1,8 +1,9 @@
-use crate::{ast::types::TypeRef, lexer::token::OperatorKind, parser::Parser};
+use crate::{ast::types::TypeRef, errors::span::Span, lexer::token::OperatorKind, parser::Parser};
 use anyhow::Result;
 
 pub struct FnReturn {
     pub type_ref: TypeRef,
+    pub span: Span,
 }
 
 impl std::fmt::Display for FnReturn {
@@ -20,7 +21,10 @@ impl FnReturn {
             OperatorKind::Greater,
         ))?;
         let type_ref = TypeRef::parse_type_ref(parser)?;
+        let span = match type_ref.clone() {
+            TypeRef::Name { name: _name, span } => span,
+        };
 
-        Ok(FnReturn { type_ref })
+        Ok(FnReturn { type_ref, span })
     }
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -6,6 +6,7 @@ use crate::{
 use anyhow::Result;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+#[derive(Debug, Clone)]
 pub enum TypeRef {
     Name { name: String, span: Span },
 }


### PR DESCRIPTION
spans

Add span information to function parameters and return types for better error reporting.